### PR TITLE
Use pico-sdk definitions for register offsets, bits and reset values

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        submodules: true
 
     # Linux deps
     - name: Install deps

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pico-sdk"]
+	path = pico-sdk
+	url = https://github.com/raspberrypi/pico-sdk

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(pico-sdk-stub.cmake)
+
 add_library(DERPCore INTERFACE)
 
 target_sources(DERPCore INTERFACE
@@ -15,3 +17,4 @@ target_sources(DERPCore INTERFACE
 )
 
 target_include_directories(DERPCore INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(DERPCore INTERFACE hardware_regs)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -17,4 +17,4 @@ target_sources(DERPCore INTERFACE
 )
 
 target_include_directories(DERPCore INTERFACE ${CMAKE_CURRENT_LIST_DIR})
-target_link_libraries(DERPCore INTERFACE hardware_regs)
+target_link_libraries(DERPCore INTERFACE hardware_regs hardware_structs)

--- a/core/Clocks.cpp
+++ b/core/Clocks.cpp
@@ -1,5 +1,9 @@
 #include <cstdio>
 
+#include "hardware/regs/clocks.h"
+#include "hardware/regs/pll.h"
+#define _u(x) x##u
+
 #include "Clocks.h"
 
 #include "MemoryBus.h"
@@ -14,19 +18,19 @@ static const char *clockNames[]{"GPOUT0", "GPOUT1", "GPOUT2", "GPOUT3", "REF", "
 void Clocks::reset()
 {
     for(auto &reg : ctrl)
-        reg = 0;
+        reg = CLOCKS_CLK_GPOUT0_CTRL_RESET;
 
     for(auto &reg : div)
-        reg = 1 << 8;
+        reg = CLOCKS_CLK_GPOUT0_DIV_RESET;
 
     for(auto &clock : clockFreq)
         clock = 0;
 
-    pllSysCS = pllUSBCS = 1;
-    pllSysPWR = pllUSBPWR = 0b101101;
-    pllSysFBDIV = pllUSBFBDIV = 0;
+    pllSysCS = pllUSBCS = PLL_CS_RESET;
+    pllSysPWR = pllUSBPWR = PLL_PWR_RESET;
+    pllSysFBDIV = pllUSBFBDIV = PLL_FBDIV_INT_RESET;
 
-    pllSysPRIM = pllUSBPRIM = 7 << 16 | 7 << 12;
+    pllSysPRIM = pllUSBPRIM = PLL_PRIM_RESET;
 
     // calcutate always enabled clocks
     calcFreq(4); // REF
@@ -69,22 +73,22 @@ void Clocks::addClockTarget(int clock, ClockTarget &target)
 
 uint32_t Clocks::regRead(uint32_t addr)
 {
-    if(addr < 0x78)
+    if(addr < CLOCKS_CLK_SYS_RESUS_CTRL_OFFSET)
     {
         // ctrl, div, selected x10
         int clock = addr / 12;
-        int reg = addr / 4 % 3;
+        int reg = addr % 12;
 
-        if(reg == 0) // ctrl
+        if(reg == CLOCKS_CLK_GPOUT0_CTRL_OFFSET)
             return ctrl[clock];
-        else if(reg == 1) // div
+        else if(reg == CLOCKS_CLK_GPOUT0_DIV_OFFSET)
             return div[clock];
-        else if(reg == 2) // selected
+        else if(reg == CLOCKS_CLK_GPOUT0_SELECTED_OFFSET)
         {
             if(clock == 4) // REF
-                return 1 << (ctrl[clock] & 0x3); // TODO: doesn't change instantly
+                return 1 << (ctrl[clock] & CLOCKS_CLK_REF_CTRL_SRC_BITS); // TODO: doesn't change instantly
             else if(clock == 5) // SYS
-                return 1 << (ctrl[clock] & 1);
+                return 1 << (ctrl[clock] & CLOCKS_CLK_SYS_CTRL_SRC_BITS);
 
             return 1;
         }
@@ -102,23 +106,23 @@ void Clocks::regWrite(uint32_t addr, uint32_t data)
 
     static const char *op[]{" = ", " ^= ", " |= ", " &= ~"};
 
-    if(addr < 0x78)
+    if(addr < CLOCKS_CLK_SYS_RESUS_CTRL_OFFSET)
     {
         //ctrl,div,selected x10
         int clock = addr / 12;
-        int reg = addr / 4 % 3;
+        int reg = addr % 12;
 
         bool changed = false;
 
-        if(reg == 0) // ctrl
+        if(reg == CLOCKS_CLK_GPOUT0_CTRL_OFFSET)
             changed = updateReg(ctrl[clock], data, atomic);
-        else if(reg == 1) // div
+        else if(reg == CLOCKS_CLK_GPOUT0_DIV_OFFSET)
             changed = updateReg(div[clock], data, atomic);
 
         // update clock freq
         if(changed)
         {
-            bool enabled = clock == 4 || clock == 5 || (ctrl[clock] & (1 << 11)/*ENABLE*/);
+            bool enabled = clock == 4/*REF*/ || clock == 5/*SYS*/ || (ctrl[clock] & CLOCKS_CLK_GPOUT0_CTRL_ENABLE_BITS);
             if(enabled)
                 calcFreq(clock);
             else
@@ -133,13 +137,13 @@ uint32_t Clocks::pllSysRegRead(uint32_t addr)
 {
     switch(addr)
     {
-        case 0x0: // CS
-            return pllSysCS | (1 << 31)/*LOCK*/;
-        case 0x4: // PWR
+        case PLL_CS_OFFSET:
+            return pllSysCS | PLL_CS_LOCK_BITS;
+        case PLL_PWR_OFFSET:
             return pllSysPWR;
-        case 0x8: // FBDIV_INT
+        case PLL_FBDIV_INT_OFFSET:
             return pllSysFBDIV;
-        case 0xC: // PRIM
+        case PLL_PRIM_OFFSET:
             return pllSysPRIM;
     }
 
@@ -153,16 +157,16 @@ void Clocks::pllSysRegWrite(uint32_t addr, uint32_t data)
 
     switch(addr)
     {
-        case 0x0: // CS
-            updateReg(pllSysCS, data & ~(1 << 31), atomic);
+        case PLL_CS_OFFSET:
+            updateReg(pllSysCS, data & ~PLL_CS_LOCK_BITS, atomic);
             break;
-        case 0x4: // PWR
+        case PLL_PWR_OFFSET:
             updateReg(pllSysPWR, data, atomic);
             break;
-        case 0x8: // FBDIV_INT
+        case PLL_FBDIV_INT_OFFSET:
             updateReg(pllSysFBDIV, data, atomic);
             break;
-        case 0xC: // PRIM
+        case PLL_PRIM_OFFSET:
             updateReg(pllSysPRIM, data, atomic);
             break;
     }
@@ -177,13 +181,13 @@ uint32_t Clocks::pllUSBRegRead(uint32_t addr)
 {
     switch(addr)
     {
-        case 0x0: // CS
-            return pllUSBCS | (1 << 31)/*LOCK*/;
-        case 0x4: // PWR
+        case PLL_CS_OFFSET:
+            return pllUSBCS | PLL_CS_LOCK_BITS;
+        case PLL_PWR_OFFSET:
             return pllUSBPWR;
-        case 0x8: // FBDIV_INT
+        case PLL_FBDIV_INT_OFFSET:
             return pllUSBFBDIV;
-        case 0xC: // PRIM
+        case  PLL_PRIM_OFFSET:
             return pllUSBPRIM;
     }
 
@@ -197,16 +201,16 @@ void Clocks::pllUSBRegWrite(uint32_t addr, uint32_t data)
 
     switch(addr)
     {
-        case 0x0: // CS
-            updateReg(pllUSBCS, data & ~(1 << 31), atomic);
+        case PLL_CS_OFFSET:
+            updateReg(pllUSBCS, data & ~PLL_CS_LOCK_BITS, atomic);
             break;
-        case 0x4: // PWR
+        case PLL_PWR_OFFSET:
             updateReg(pllUSBPWR, data, atomic);
             break;
-        case 0x8: // FBDIV_INT
+        case PLL_FBDIV_INT_OFFSET:
             updateReg(pllUSBFBDIV, data, atomic);
             break;
-        case 0xC: // PRIM
+        case PLL_PRIM_OFFSET:
             updateReg(pllUSBPRIM, data, atomic);
             break;
     }
@@ -226,8 +230,13 @@ void Clocks::calcFreq(int clock)
     {
         // TODO: bypass
         // TODO: cache?
-        if(!(pllSysPWR & 1))
-            return (xoscFreq / (pllSysCS & 0x3F)) * pllSysFBDIV / (((pllSysPRIM >> 16) & 7) * ((pllSysPRIM >> 12) & 7));
+        if(!(pllSysPWR & PLL_PWR_VCOPD_RESET))
+        {
+            auto refDiv = pllSysCS & PLL_CS_REFDIV_BITS;
+            auto postdiv1 = (pllSysPRIM & PLL_PRIM_POSTDIV1_BITS) >> PLL_PRIM_POSTDIV1_LSB;
+            auto postdiv2 = (pllSysPRIM & PLL_PRIM_POSTDIV2_BITS) >> PLL_PRIM_POSTDIV2_LSB;
+            return (xoscFreq / refDiv) * pllSysFBDIV / (postdiv1 * postdiv2);
+        }
 
         return 0u;
     };
@@ -236,8 +245,13 @@ void Clocks::calcFreq(int clock)
     {
         // TODO: bypass
         // TODO: cache?
-        if(!(pllUSBPWR & 1))
-            return (xoscFreq / (pllSysCS & 0x3F)) * pllUSBFBDIV / (((pllUSBPRIM >> 16) & 7) * ((pllUSBPRIM >> 12) & 7));
+        if(!(pllUSBPWR & PLL_PWR_VCOPD_RESET))
+        {
+            auto refDiv = pllUSBCS & PLL_CS_REFDIV_BITS;
+            auto postdiv1 = (pllUSBPRIM & PLL_PRIM_POSTDIV1_BITS) >> PLL_PRIM_POSTDIV1_LSB;
+            auto postdiv2 = (pllUSBPRIM & PLL_PRIM_POSTDIV2_BITS) >> PLL_PRIM_POSTDIV2_LSB;
+            return (xoscFreq / refDiv) * pllUSBFBDIV / (postdiv1 * postdiv2);
+        }
 
         return 0u;
     };
@@ -255,21 +269,21 @@ void Clocks::calcFreq(int clock)
 
         case 4: // REF
         {
-            int src = ctrl[clock] & 3;
-            int clkDiv = div[clock] >> 8; // no frac
+            int src = ctrl[clock] & CLOCKS_CLK_REF_CTRL_SRC_BITS;
+            int clkDiv = (div[clock] & CLOCKS_CLK_REF_DIV_INT_BITS) >> CLOCKS_CLK_REF_DIV_INT_LSB; // no frac
             if(!clkDiv)
                 clkDiv = 1 << 16;
 
-            if(src == 0)
+            if(src == CLOCKS_CLK_REF_CTRL_SRC_VALUE_ROSC_CLKSRC_PH)
                 clockFreq[clock] = roscFreq / clkDiv;
-            else if(src == 1) // aux
+            else if(src == CLOCKS_CLK_REF_CTRL_SRC_VALUE_CLKSRC_CLK_REF_AUX)
             {
-                int aux = (ctrl[4] >> 5) & 0x3;
-                if(aux == 0)
+                int aux = (ctrl[clock] & CLOCKS_CLK_REF_CTRL_AUXSRC_BITS) >> CLOCKS_CLK_REF_CTRL_AUXSRC_LSB;
+                if(aux == CLOCKS_CLK_REF_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB)
                     clockFreq[clock] = getPLLUSBFreq() / clkDiv;
                 // else gpin0/1
             }
-            else if(src == 2)
+            else if(src == CLOCKS_CLK_REF_CTRL_SRC_VALUE_XOSC_CLKSRC)
                 clockFreq[clock] = xoscFreq / clkDiv;
 
             break;
@@ -277,25 +291,25 @@ void Clocks::calcFreq(int clock)
 
         case 5: // SYS
         {
-            int src = ctrl[clock] & 3;
+            int src = ctrl[clock] & CLOCKS_CLK_SYS_CTRL_SRC_BITS;
             int clkDiv = div[clock];
 
-            if(!(clkDiv >> 8))
+            if(!(clkDiv >> CLOCKS_CLK_SYS_DIV_INT_LSB))
                 clkDiv |= 1 << 24;
 
-            if(src == 0)
+            if(src == CLOCKS_CLK_SYS_CTRL_SRC_VALUE_CLK_REF)
                 clockFreq[clock] = divClock(clockFreq[4], clkDiv); // REF
             else // aux
             {
-                int aux = (ctrl[clock] >> 5) & 0x7;
+                int aux = (ctrl[clock] & CLOCKS_CLK_SYS_CTRL_AUXSRC_BITS) >> CLOCKS_CLK_SYS_CTRL_AUXSRC_LSB;
 
-                if(aux == 0)
+                if(aux == CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS)
                     clockFreq[clock] = divClock(getPLLSysFreq(), clkDiv);
-                else if(aux == 1)
+                else if(aux == CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB)
                     clockFreq[clock] = divClock(getPLLUSBFreq(), clkDiv);
-                else if(aux == 2)
+                else if(aux == CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_ROSC_CLKSRC)
                     clockFreq[clock] = divClock(roscFreq, clkDiv);
-                else if(aux == 3)
+                else if(aux == CLOCKS_CLK_SYS_CTRL_AUXSRC_VALUE_XOSC_CLKSRC)
                     clockFreq[clock] = divClock(xoscFreq, clkDiv);
                 // else gpin0/1
             }
@@ -305,18 +319,18 @@ void Clocks::calcFreq(int clock)
 
         case 6: // PERI
         {
-            int aux = (ctrl[clock] >> 5) & 0x7;
+            int aux = (ctrl[clock] & CLOCKS_CLK_PERI_CTRL_AUXSRC_BITS) >> CLOCKS_CLK_PERI_CTRL_AUXSRC_LSB;
             // no div
 
-            if(aux == 0)
+            if(aux == CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLK_SYS)
                 clockFreq[clock] = clockFreq[5]; // SYS
-            else if(aux == 1)
+            else if(aux == CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS)
                 clockFreq[clock] = getPLLSysFreq();
-            else if(aux == 2)
+            else if(aux == CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB)
                 clockFreq[clock] = getPLLUSBFreq();
-            else if(aux == 3)
+            else if(aux == CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_ROSC_CLKSRC_PH)
                 clockFreq[clock] = roscFreq;
-            else if(aux == 4)
+            else if(aux == CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_XOSC_CLKSRC)
                 clockFreq[clock] = xoscFreq;
             // else gpin0/1
 
@@ -327,21 +341,21 @@ void Clocks::calcFreq(int clock)
         case 8: // ADC
         case 9: // RTC
         {
-            int aux = (ctrl[clock] >> 5) & 0x7;
+            int aux = (ctrl[clock] & CLOCKS_CLK_USB_CTRL_AUXSRC_BITS) >> CLOCKS_CLK_USB_CTRL_AUXSRC_LSB;
 
             // TODO: RTC has fractional divider
-            int clkDiv = div[clock] >> 8;
+            int clkDiv = div[clock] >> CLOCKS_CLK_USB_DIV_INT_LSB;
 
             if(!clkDiv)
                 clkDiv = 1 << 16;
 
-            if(aux == 0)
+            if(aux == CLOCKS_CLK_USB_CTRL_AUXSRC_VALUE_CLKSRC_PLL_USB)
                 clockFreq[clock] = getPLLUSBFreq() / clkDiv;
-            else if(aux == 1)
+            else if(aux == CLOCKS_CLK_USB_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS)
                 clockFreq[clock] = getPLLSysFreq() / clkDiv;
-            else if(aux == 2)
+            else if(aux == CLOCKS_CLK_USB_CTRL_AUXSRC_VALUE_ROSC_CLKSRC_PH)
                 clockFreq[clock] = roscFreq / clkDiv;
-            else if(aux == 3)
+            else if(aux == CLOCKS_CLK_USB_CTRL_AUXSRC_VALUE_XOSC_CLKSRC)
                 clockFreq[clock] = xoscFreq / clkDiv;
             // else gpin0/1
             break;

--- a/core/Clocks.h
+++ b/core/Clocks.h
@@ -3,6 +3,9 @@
 #include <cstdint>
 #include <map>
 
+#include "hardware/structs/clocks.h"
+#include "hardware/structs/pll.h"
+
 #include "ClockTarget.h"
 
 class Clocks final
@@ -29,15 +32,11 @@ public:
 private:
     void calcFreq(int clock);
 
-    uint32_t ctrl[10];
-    uint32_t div[10];
+    clocks_hw_t hw;
 
-    uint32_t clockFreq[10];
+    uint32_t clockFreq[CLK_COUNT];
 
-    uint32_t pllSysCS, pllUSBCS;
-    uint32_t pllSysPWR, pllUSBPWR;
-    uint32_t pllSysFBDIV, pllUSBFBDIV;
-    uint32_t pllSysPRIM, pllUSBPRIM;
+    pll_hw_t pllSys, pllUSB;
 
     std::multimap<int, ClockTarget &> targets;
 };

--- a/core/DMA.h
+++ b/core/DMA.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "hardware/platform_defs.h"
+
 #include "ClockTarget.h"
 
 class MemoryBus;
@@ -34,7 +36,8 @@ private:
 
     int curChannel;
 
-    static const int numChannels = 12;
+    // not using the structs here, too much repetition+padding
+    static const int numChannels = NUM_DMA_CHANNELS;
     uint32_t readAddr[numChannels];
     uint32_t writeAddr[numChannels];
     uint32_t transferCount[numChannels], transferCountReload[numChannels];

--- a/core/GPIO.cpp
+++ b/core/GPIO.cpp
@@ -1,5 +1,10 @@
 #include <cstdio>
 
+#include "hardware/platform_defs.h"
+#include "hardware/regs/io_bank0.h"
+#include "hardware/regs/intctrl.h"
+#include "hardware/regs/pads_bank0.h"
+
 #include "GPIO.h"
 
 #include "MemoryBus.h"
@@ -16,19 +21,19 @@ GPIO::GPIO(MemoryBus &mem) : mem(mem)
 void GPIO::reset()
 {
     for(auto &reg : ctrl)
-        reg = 0;
+        reg = IO_BANK0_GPIO0_CTRL_RESET;
 
     for(auto &reg : interrupts)
-        reg = 0;
+        reg = IO_BANK0_INTR0_RESET;
 
     for(auto &reg : proc0InterruptEnables)
-        reg = 0;
+        reg = IO_BANK0_PROC0_INTE0_RESET;
 
     for(auto &reg : padControl)
-        reg = 0b0110110;
+        reg = PADS_BANK0_GPIO0_RESET;
 
-    padControl[30] = 0b1111010;
-    padControl[31] = 0b0111010;
+    padControl[30] = PADS_BANK0_SWCLK_RESET;
+    padControl[31] = PADS_BANK0_SWD_RESET;
 
     inputs = 0;
     outputs = 0;
@@ -55,19 +60,19 @@ void GPIO::setInputs(uint32_t inputs)
             bool oldState = this->inputs & (1 << i);
 
             // TODO: level should stick
-            if(!newState && (p0IntEn & (1 << 0))) // LEVEL_LOW
+            if(!newState && (p0IntEn & IO_BANK0_PROC0_INTE0_GPIO0_LEVEL_LOW_BITS))
                 interrupts[i / 8] |= 1 << (ioShift + 0);
-            else if(newState && (p0IntEn & (1 << 1))) // LEVEL_HIGH
+            else if(newState && (p0IntEn & IO_BANK0_PROC0_INTE0_GPIO0_LEVEL_HIGH_BITS))
                 interrupts[i / 8] |= 1 << (ioShift + 1);
-            else if(!newState && oldState && (p0IntEn & (1 << 2))) // EDGE_LOW
+            else if(!newState && oldState && (p0IntEn & IO_BANK0_PROC0_INTE0_GPIO0_EDGE_LOW_BITS))
                 interrupts[i / 8] |= 1 << (ioShift + 2);
-            else if(newState && !oldState && (p0IntEn & (1 << 3))) // EDGE_HIGH
+            else if(newState && !oldState && (p0IntEn & IO_BANK0_PROC0_INTE0_GPIO0_EDGE_HIGH_BITS))
                 interrupts[i / 8] |= 1 << (ioShift + 3);
 
             if(interrupts[i / 8] & proc0InterruptEnables[i / 8])
             {
                 // TODO: only to one core
-                mem.setPendingIRQ(13);// IO_IRQ_BANK0
+                mem.setPendingIRQ(IO_IRQ_BANK0);
             }
         }
     }
@@ -100,19 +105,19 @@ void GPIO::setReadCallback(ReadCallback cb)
 
 uint32_t GPIO::regRead(uint32_t addr)
 {
-    if(addr < 0xF0)
+    if(addr < IO_BANK0_INTR0_OFFSET)
     {
-        if(addr & 4) // GPIOx_STATUS
+        if(addr & 4) // GPIOx_CTRL
             return ctrl[addr / 8];
         // else status
     }
-    else if(addr < 0x100) // INTR0-3
-        return interrupts[(addr - 0xF0) / 4];
-    else if(addr < 0x110) // PROC0_INTE0-3
-        return proc0InterruptEnables[(addr - 0x100) / 4];
-    else if(addr >= 0x120 && addr < 0x130) // PROC0_INTS0-3
+    else if(addr < IO_BANK0_PROC0_INTE0_OFFSET) // INTR0-3
+        return interrupts[(addr - IO_BANK0_INTR0_OFFSET) / 4];
+    else if(addr < IO_BANK0_PROC0_INTF0_OFFSET) // PROC0_INTE0-3
+        return proc0InterruptEnables[(addr - IO_BANK0_PROC0_INTE0_OFFSET) / 4];
+    else if(addr >= IO_BANK0_PROC0_INTS0_OFFSET && addr < IO_BANK0_PROC1_INTE0_OFFSET) // PROC0_INTS0-3
     {
-        int index = (addr - 0x120) / 4;
+        int index = (addr - IO_BANK0_PROC0_INTS0_OFFSET) / 4;
         // TODO: force
         return interrupts[index] & proc0InterruptEnables[index];
     }
@@ -129,26 +134,26 @@ void GPIO::regWrite(uint32_t addr, uint32_t data)
 
     static const char *op[]{" = ", " ^= ", " |= ", " &= ~"};
 
-    if(addr < 0xF0)
+    if(addr < IO_BANK0_INTR0_OFFSET)
     {
-        if(addr & 4) // GPIOx_STATUS
+        if(addr & 4) // GPIOx_CTRL
         {
             updateReg(ctrl[addr / 8], data, atomic);
             return;
         }
         // else status
     }
-    else if(addr < 0x100) // INTR0-3
+    else if(addr < IO_BANK0_PROC0_INTE0_OFFSET) // INTR0-3
     {
         if(atomic == 0)
         {
-            interrupts[(addr - 0xF0) / 4] &= ~(data & 0xCCCCCCCC);
+            interrupts[(addr - IO_BANK0_INTR0_OFFSET) / 4] &= ~(data & 0xCCCCCCCC); // level can't be cleared
             return;
         }
     }
     else if(addr < 0x110) // PROC0_INTE0-3
     {
-        updateReg(proc0InterruptEnables[(addr - 0x100) / 4], data, atomic);
+        updateReg(proc0InterruptEnables[(addr - IO_BANK0_PROC0_INTE0_OFFSET) / 4], data, atomic);
         return;
     }
 
@@ -157,11 +162,11 @@ void GPIO::regWrite(uint32_t addr, uint32_t data)
 
 uint32_t GPIO::padsRegRead(uint32_t addr)
 {
-    if(addr == 0)
+    if(addr == PADS_BANK0_VOLTAGE_SELECT_OFFSET)
     {
         logf(LogLevel::NotImplemented, logComponent, "PADS_BANK0 R VOLTAGE_SELECT");
     }
-    else if(addr <= 0x80)
+    else if(addr <= PADS_BANK0_SWD_OFFSET)
     {
         int gpio = addr / 4 - 1;
         return padControl[gpio];
@@ -179,11 +184,11 @@ void GPIO::padsRegWrite(uint32_t addr, uint32_t data)
 
     static const char *op[]{" = ", " ^= ", " |= ", " &= ~"};
 
-    if(addr == 0)
+    if(addr == PADS_BANK0_VOLTAGE_SELECT_OFFSET)
     {
         logf(LogLevel::NotImplemented, logComponent, "PADS_BANK0 VOLTAGE_SELECT%s%08X", op[atomic], data);
     }
-    else if(addr <= 0x80)
+    else if(addr <= PADS_BANK0_SWD_OFFSET)
     {
         int gpio = addr / 4 - 1;
         if(updateReg(padControl[gpio], data, atomic))

--- a/core/GPIO.h
+++ b/core/GPIO.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <functional>
 
+#include "hardware/structs/iobank0.h"
+
 class MemoryBus;
 
 class GPIO final
@@ -48,11 +50,9 @@ public:
 private:
     MemoryBus &mem;
 
-    uint32_t ctrl[30];
-    uint32_t interrupts[4];
-    uint32_t proc0InterruptEnables[4]; // TODO: proc1
+    iobank0_hw_t io;
 
-    uint32_t padControl[32]; // GPIO0-29, SWCLK, SWD
+    uint32_t padControl[NUM_BANK0_GPIOS + 2]; // GPIO0-29, SWCLK, SWD
 
     uint32_t inputs;
     uint32_t outputs;

--- a/core/MemoryBus.cpp
+++ b/core/MemoryBus.cpp
@@ -53,6 +53,54 @@ enum MemoryRegion
     Region_CPUInternal   = PPB_BASE >> 24,
 };
 
+// peripherals
+#define PERIPH(x) ((x##_BASE >> 14) & 0x1F)
+
+enum class APBPeripheral
+{
+    SysInfo = PERIPH(SYSINFO),
+    SysCfg = PERIPH(SYSCFG),
+    Clocks = PERIPH(CLOCKS),
+    Resets = PERIPH(RESETS),
+    PSM = PERIPH(PSM),
+    IO_Bank0 = PERIPH(IO_BANK0),
+    IO_QSPI = PERIPH(IO_QSPI),
+    Pads_Bank0 = PERIPH(PADS_BANK0),
+    Pads_QSPI = PERIPH(PADS_QSPI),
+    XOsc = PERIPH(XOSC),
+    PLL_Sys = PERIPH(PLL_SYS),
+    PLL_USB = PERIPH(PLL_USB),
+    BusCtrl = PERIPH(BUSCTRL),
+    UART0 = PERIPH(UART0),
+    UART1 = PERIPH(UART1),
+    SPI0 = PERIPH(SPI0),
+    SPI1 = PERIPH(SPI1),
+    I2C0 = PERIPH(I2C0),
+    I2C1 = PERIPH(I2C1),
+    ADC = PERIPH(ADC),
+    PWM = PERIPH(PWM),
+    Timer = PERIPH(TIMER),
+    Watchdog = PERIPH(WATCHDOG),
+    RTC = PERIPH(RTC),
+    ROsc = PERIPH(ROSC),
+    VRegAndChipReset = PERIPH(VREG_AND_CHIP_RESET),
+    TBMan = PERIPH(TBMAN),
+};
+
+#undef PERIPH
+#define PERIPH(x) ((x##_BASE >> 20) & 0xF)
+
+enum class AHBPeripheral
+{
+    DMA = PERIPH(DMA),
+    USB = PERIPH(USBCTRL),
+    PIO0 = PERIPH(PIO0),
+    PIO1 = PERIPH(PIO1),
+    XIPAux = PERIPH(XIP_AUX),
+};
+
+#undef PERIPH
+
 template uint8_t MemoryBus::read(BusMasterPtr master, uint32_t addr, int &cycles, bool sequential);
 template uint16_t MemoryBus::read(BusMasterPtr master, uint32_t addr, int &cycles, bool sequential);
 template uint32_t MemoryBus::read(BusMasterPtr master, uint32_t addr, int &cycles, bool sequential);

--- a/core/MemoryBus.cpp
+++ b/core/MemoryBus.cpp
@@ -1011,6 +1011,7 @@ void MemoryBus::doAHBPeriphWrite(ClockTarget &masterClock, uint32_t addr, uint8_
     {
         usb.update(masterClock.getTime());
         usb.getRAM()[addr & 0xFFF] = data;
+        usb.ramWrite(addr & 0xFFF);
         return;
     }
 
@@ -1024,6 +1025,7 @@ void MemoryBus::doAHBPeriphWrite(ClockTarget &masterClock, uint32_t addr, uint16
     {
         usb.update(masterClock.getTime());
         *reinterpret_cast<uint16_t *>(usb.getRAM() + (addr & 0xFFF)) = data;
+        usb.ramWrite(addr & 0xFFF);
         return;
     }
 

--- a/core/UART.cpp
+++ b/core/UART.cpp
@@ -18,10 +18,10 @@ UART::UART(MemoryBus &mem, int index) : mem(mem), index(index)
 
 void UART::reset()
 {
-    baudInt = UART_UARTIBRD_RESET;
-    baudFrac = UART_UARTFBRD_RESET;
-    lcr = UART_UARTLCR_H_RESET;
-    cr = UART_UARTCR_RESET;
+    hw.ibrd = UART_UARTIBRD_RESET;
+    hw.fbrd = UART_UARTFBRD_RESET;
+    hw.lcr_h = UART_UARTLCR_H_RESET;
+    hw.cr = UART_UARTCR_RESET;
 
     txDataOff = 0;
 }
@@ -33,13 +33,13 @@ uint32_t UART::regRead(uint32_t addr)
         case UART_UARTFR_OFFSET:
             return UART_UARTFR_RXFE_BITS | UART_UARTFR_TXFE_BITS; // FIFOs empty
         case UART_UARTIBRD_OFFSET:
-            return baudInt;
+            return hw.ibrd;
         case UART_UARTFBRD_OFFSET:
-            return baudFrac;
+            return hw.fbrd;
         case UART_UARTLCR_H_OFFSET:
-            return lcr;
+            return hw.lcr_h;
         case UART_UARTCR_OFFSET:
-            return cr;
+            return hw.cr;
     }
 
     logf(LogLevel::NotImplemented, logComponent, "%i R %04X", index, addr);
@@ -70,16 +70,16 @@ void UART::regWrite(uint32_t addr, uint32_t data)
             }
             return;
         case UART_UARTIBRD_OFFSET:
-            updateReg(baudInt, data, atomic);
+            updateReg(hw.ibrd, data, atomic);
             return;
         case UART_UARTFBRD_OFFSET:
-            updateReg(baudFrac, data, atomic);
+            updateReg(hw.fbrd, data, atomic);
             return;
         case UART_UARTLCR_H_OFFSET:
-            updateReg(lcr, data, atomic);
+            updateReg(hw.lcr_h, data, atomic);
             return;
         case UART_UARTCR_OFFSET:
-            updateReg(cr, data, atomic);
+            updateReg(hw.cr, data, atomic);
             return;
     }
 

--- a/core/UART.h
+++ b/core/UART.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#include "hardware/structs/uart.h"
+
 class MemoryBus;
 
 class UART final
@@ -18,10 +20,7 @@ private:
     MemoryBus &mem;
     int index;
 
-    uint32_t baudInt;
-    uint32_t baudFrac;
-    uint32_t lcr;
-    uint32_t cr;
+    uart_hw_t hw;
 
     int txDataOff;
     uint8_t txData[1024];

--- a/core/USB.cpp
+++ b/core/USB.cpp
@@ -307,13 +307,32 @@ void USB::updateInterrupts()
     interrupts &= ~mask;
 
     // copy bits from SIE_STATUS
+    if(sieStatus & USB_SIE_STATUS_VBUS_DETECTED_BITS)
+        interrupts |= USB_INTS_VBUS_DETECT_BITS;
     if(sieStatus & USB_SIE_STATUS_SETUP_REC_BITS)
         interrupts |= USB_INTS_SETUP_REQ_BITS; 
     if(sieStatus & USB_SIE_STATUS_TRANS_COMPLETE_BITS)
         interrupts |= USB_INTS_TRANS_COMPLETE_BITS;
     if(sieStatus & USB_SIE_STATUS_BUS_RESET_BITS)
         interrupts |= USB_INTS_BUS_RESET_BITS;
+    if(sieStatus & USB_SIE_STATUS_CRC_ERROR_BITS)
+        interrupts |= USB_INTS_ERROR_CRC_BITS;
+    if(sieStatus & USB_SIE_STATUS_BIT_STUFF_ERROR_BITS)
+        interrupts |= USB_INTS_ERROR_BIT_STUFF_BITS;
+    if(sieStatus & USB_SIE_STATUS_RX_OVERFLOW_BITS)
+        interrupts |= USB_INTS_ERROR_RX_OVERFLOW_BITS;
+    if(sieStatus & USB_SIE_STATUS_RX_TIMEOUT_BITS)
+        interrupts |= USB_INTS_ERROR_RX_TIMEOUT_BITS;
+    if(sieStatus & USB_SIE_STATUS_DATA_SEQ_ERROR_BITS)
+        interrupts |= USB_INTS_ERROR_DATA_SEQ_BITS;
+    if(sieStatus & USB_SIE_STATUS_STALL_REC_BITS)
+        interrupts |= USB_INTS_STALL_BITS;
 
+    //TODO: STALL_NAK
+
+    if(epAbortDone)
+        interrupts |= USB_INTS_ABORT_DONE_BITS;
+    
     // set buff status
     if(buffStatus[0] | buffStatus[1])
         interrupts |= USB_INTS_BUFF_STATUS_BITS;

--- a/core/USB.h
+++ b/core/USB.h
@@ -44,6 +44,19 @@ public:
     bool usbipUnlink(struct usbip_client *client, uint32_t seqnum);
 
 private:
+    enum class EnumerationState
+    {
+        NotStarted = 0,
+        RequestDeviceDesc,
+        ReadDeviceDesc, // and reset
+        SetAddress,
+        RequestConfigDesc,
+        RequestFullConfigDesc,
+        ReadConfigDesc, // and set config OR init usbip
+        InitCDC, // if found
+        Done
+    };
+
     void updateInterrupts();
 
     void updateEnumeration();
@@ -69,7 +82,7 @@ private:
     uint32_t interrupts;
     uint32_t interruptEnables;
 
-    int enumerationState;
+    EnumerationState enumerationState;
     uint8_t deviceDesc[18];
     uint8_t *configDesc;
     int configDescLen, configDescOffset;

--- a/core/Watchdog.cpp
+++ b/core/Watchdog.cpp
@@ -18,8 +18,8 @@ Watchdog::Watchdog(MemoryBus &mem) : mem(mem)
 
 void Watchdog::reset()
 {
-    ctrl = 7 << 24;
-    tick = 1 << 9;
+    ctrl = WATCHDOG_CTRL_RESET;
+    tick = WATCHDOG_TICK_RESET;
 
     clock.reset();
 

--- a/core/hardware/address_mapped.h
+++ b/core/hardware/address_mapped.h
@@ -4,7 +4,7 @@
 
 #include <stdint.h>
 
-#define _u(x) x##u
+#include "hardware/platform_defs.h"
 
 #define _REG_(x)
 

--- a/core/hardware/address_mapped.h
+++ b/core/hardware/address_mapped.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// pico-sdk hardware_base stub
+
+#include <stdint.h>
+
+#define _u(x) x##u
+
+#define _REG_(x)
+
+// not volatile or const
+typedef uint32_t io_rw_32;
+typedef uint32_t io_ro_32;
+typedef uint32_t io_wo_32;
+typedef uint16_t io_rw_16;
+typedef uint16_t io_ro_16;
+typedef uint16_t io_wo_16;
+typedef uint8_t io_rw_8;
+typedef uint8_t io_ro_8;
+typedef uint8_t io_wo_8;

--- a/core/pico-sdk-stub.cmake
+++ b/core/pico-sdk-stub.cmake
@@ -1,0 +1,33 @@
+# stub pico-sdk functions
+function(pico_add_library target)
+    add_library(${target}_headers INTERFACE)
+    add_library(${target} INTERFACE)
+    target_link_libraries(${target} INTERFACE ${target}_headers)
+endfunction()
+
+function(pico_add_subdirectory subdir)
+    add_subdirectory(${subdir})
+endfunction()
+
+function(pico_add_doxygen)
+endfunction()
+
+function(pico_add_doxygen_exclude)
+endfunction()
+
+function(pico_mirrored_target_link_libraries TARGET SCOPE)
+    target_link_libraries(${TARGET} ${SCOPE} ${TARGET}_headers)
+    foreach(DEPENDENCY IN LISTS ARGN)
+        target_link_libraries(${TARGET}_headers ${SCOPE} ${DEPENDENCY}_headers)
+        target_link_libraries(${TARGET} ${SCOPE} ${DEPENDENCY})
+    endforeach()
+endfunction()
+
+macro(pico_promote_common_scope_vars)
+endmacro()
+
+# include enough to get hardware_regs
+add_subdirectory(../pico-sdk/src/host/pico_platform pico-sdk-pico-platform)
+add_subdirectory(../pico-sdk/src/common/pico_base pico-sdk-pico-base)
+add_subdirectory(../pico-sdk/src/rp2_common/hardware_base pico-sdk-hw-base)
+add_subdirectory(../pico-sdk/src/rp2040 pico-sdk-rp2040)

--- a/core/pico-sdk-stub.cmake
+++ b/core/pico-sdk-stub.cmake
@@ -1,10 +1,4 @@
 # stub pico-sdk functions
-function(pico_add_library target)
-    add_library(${target}_headers INTERFACE)
-    add_library(${target} INTERFACE)
-    target_link_libraries(${target} INTERFACE ${target}_headers)
-endfunction()
-
 function(pico_add_subdirectory subdir)
     add_subdirectory(${subdir})
 endfunction()
@@ -26,8 +20,9 @@ endfunction()
 macro(pico_promote_common_scope_vars)
 endmacro()
 
+# stub hardware_base
+add_library(hardware_base INTERFACE)
+add_library(hardware_base_headers INTERFACE)
+
 # include enough to get hardware_regs
-add_subdirectory(../pico-sdk/src/host/pico_platform pico-sdk-pico-platform)
-add_subdirectory(../pico-sdk/src/common/pico_base pico-sdk-pico-base)
-add_subdirectory(../pico-sdk/src/rp2_common/hardware_base pico-sdk-hw-base)
 add_subdirectory(../pico-sdk/src/rp2040 pico-sdk-rp2040)


### PR DESCRIPTION
Makes everything a little easier to understand. Also fixes a few minor bugs... and USB, which I broke in one of my random pushes to `main`, whoops.

Uses the structs in a few places as well. (But not when there are a lot of aliases/padding)

Fixes #1